### PR TITLE
Fix resources path

### DIFF
--- a/server/pom.xml
+++ b/server/pom.xml
@@ -17,7 +17,7 @@
         <finalName>server</finalName>
         <resources>
             <resource>
-                <directory>src/main/old</directory>
+                <directory>src/main/resources</directory>
             </resource>
         </resources>
         <plugins>


### PR DESCRIPTION
In the `pom.xml` for your server module, the directory for your resources is incorrect. This is why the autograder is not able to run correctly for your static files.

Merging in this PR should fix this issue for future phases